### PR TITLE
프로필 수정 구현 + a

### DIFF
--- a/src/main/java/Remoa/BE/Member/Controller/KakaoController.java
+++ b/src/main/java/Remoa/BE/Member/Controller/KakaoController.java
@@ -24,6 +24,7 @@ import static Remoa.BE.utill.MemberInfo.*;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
+@CrossOrigin(origins = "*") // 프론트에서 추가 요청
 public class KakaoController {
 
     private final KakaoService ks;

--- a/src/main/java/Remoa/BE/Member/Controller/ProfileController.java
+++ b/src/main/java/Remoa/BE/Member/Controller/ProfileController.java
@@ -1,0 +1,61 @@
+package Remoa.BE.Member.Controller;
+
+import Remoa.BE.Member.Domain.Member;
+import Remoa.BE.Member.Domain.MemberProfile;
+import Remoa.BE.Member.Service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ProfileController {
+
+    @Autowired
+    private ProfileService profileService;
+
+    // 프로필 수정 범위 : 닉네임(중복확인), 핸드폰번호, 대학교, 한줄소개
+    @GetMapping("/user")
+    public String editProfile(HttpServletRequest request) {
+
+        HttpSession session = request.getSession();
+        // 현재 로그인한 사용자의 세션 가져오기
+        Member loginMember = (Member) session.getAttribute("loginMember");
+
+        // 세션이 없으면 로그인 페이지로 이동
+        if (loginMember == null) {
+            return "redirect:/login/kakao";
+        }
+        return "profile edit page";
+    }
+
+    // RESTful API에서 PUT 매핑은 수정할 리소스를 명확하게 지정해야 하는데 이 경우에는 URL에 리소스 ID를 명시하는 것이 일반적이다.
+    // 그런데 우리는 수정할 사용자의 정보를 모두 입력받아 수정하는 형태이기 때문에
+    // URL에 리소스 ID를 명시할 필요가 없어서 PUT대신 POST 매핑을 사용하였습니다.
+    @PostMapping("/user")
+    public String editProfile(@RequestParam("nickname") String nickname,
+                              @RequestParam("phoneNumber") String phoneNumber,
+                              @RequestParam("university") String university,
+                              @RequestParam("oneLineIntroduction") String oneLineIntroduction,
+                              HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        Member loginMember = (Member) session.getAttribute("loginMember");
+
+        if (loginMember == null) {
+            // 로그인되어 있지 않은 경우 로그인 페이지로 이동
+            return "redirect:/login/kakao";
+        }
+        // 사용자의 입력 정보를 DTO에 담아 서비스로 전달
+        MemberProfile profileInfo = new MemberProfile(nickname, phoneNumber, university, oneLineIntroduction);
+        profileService.editProfile(loginMember.getKakaoId(), profileInfo);
+
+        // 수정이 완료되면 프로필 페이지로 이동
+        return "redirect:/user";
+    }
+
+}

--- a/src/main/java/Remoa/BE/Member/Domain/MemberProfile.java
+++ b/src/main/java/Remoa/BE/Member/Domain/MemberProfile.java
@@ -1,0 +1,17 @@
+package Remoa.BE.Member.Domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberProfile {
+
+    // 프로필 수정 범위 : 닉네임(중복확인), 핸드폰번호, 대학교(대학교 리스트 검색하기), 한줄소개
+    private String nickname;
+    private String phoneNumber;
+    private String university;
+    private String oneLineIntroduction;
+}

--- a/src/main/java/Remoa/BE/Member/Service/KakaoService.java
+++ b/src/main/java/Remoa/BE/Member/Service/KakaoService.java
@@ -50,7 +50,9 @@ public class KakaoService {
             StringBuilder sb = new StringBuilder();
             sb.append("grant_type=authorization_code");
             sb.append("&client_id=139febf9e13da4d124d1c1faafcf3f86");
-            sb.append("&redirect_uri=http://localhost:8080/login/kakao");
+
+            // 02.26. 프론트와 연동하는데 여기 3000으로 바꿔달라고 하셔서 바꿔놓았습니다 -광휘
+            sb.append("&redirect_uri=http://localhost:3000/login/kakao");
             sb.append("&code=" + code);
             sb.append("&client_secret=5IueqXws75WoH1e3gCSI2aNxQgOGMdBG");
 

--- a/src/main/java/Remoa/BE/Member/Service/ProfileService.java
+++ b/src/main/java/Remoa/BE/Member/Service/ProfileService.java
@@ -1,0 +1,41 @@
+package Remoa.BE.Member.Service;
+
+import Remoa.BE.Member.Domain.MemberProfile;
+import Remoa.BE.Member.Repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import Remoa.BE.Member.Service.MemberService;
+
+
+import Remoa.BE.Member.Domain.Member;
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ProfileService {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    private MemberService memberService;
+
+
+    @Transactional
+    public void editProfile(Long memberKakaoId, MemberProfile profile) {
+        Member member = memberRepository.findByKakaoId(memberKakaoId).orElseThrow(() -> new IllegalArgumentException("Invalid member id"));
+
+        // 닉네임이 중복되는지 검사
+        if (!memberService.isNicknameDuplicate(member)){
+            throw new IllegalArgumentException("Duplicate nickname");
+        }
+
+        // 사용자의 프로필 정보 수정
+        member.setNickname(profile.getNickname());
+        member.setPhoneNumber(profile.getPhoneNumber());
+        member.setUniversity(profile.getUniversity());
+        member.setOneLineIntroduction(profile.getOneLineIntroduction());
+    }
+}


### PR DESCRIPTION
## 개요
프로필 수정 구현과, 카카오컨트롤러, 카카오서비스 일부 수정

## 변경 사항
1. KaKaoController (수정)
@CrossOrigin(origins = "*") 추가했습니다.

2. ProfileController (추가)
세션확인
세션 없을 시 로그인 페이지로 redirect
세션 있으면 사용자의 입력 정보를 DTO에 담아 profileService로 전달

3. MemberProfile (추가)
프로필 수정 내역을 담은 DTO
nickname, phoneNumber, university, oneLineIntroduction

4. ProfileService (추가)
editProfile 메소드에서 memberKakaoId랑 수정할 profile 정보를 받아서
닉네임 중복을 체크하고(isNicknameDuplicate) 사용자의 프로필 정보를 수정

5. KaKaoService (수정)
프론트와 연동하는데 redirect 주소 3000으로 바꿔달라고 하셔서 바꿔놓았습니다.
http://localhost:3000/login/kakao
redirect 부분을 3000으로 고쳐야 연동이 된다고 하셔서 설정해놓았습니다


## 확인 방법 (스크린샷 첨부 가능)

## 한계점 / 문제점

