### PR TITLE
내 작업물 목록 페이지 구현, Post 작성시 postingTime 등 초기 값 설정, 오탈자 수정(regist->register)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 
 	// h2 db 추가
 	implementation "com.h2database:h2"
+
+	//ModelMapper 라이브러리 추가
+	implementation 'org.modelmapper:modelmapper:2.4.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/Remoa/BE/Post/Controller/MyPostController.java
+++ b/src/main/java/Remoa/BE/Post/Controller/MyPostController.java
@@ -2,19 +2,25 @@ package Remoa.BE.Post.Controller;
 
 import Remoa.BE.Member.Domain.Member;
 import Remoa.BE.Member.Service.MemberService;
-import Remoa.BE.Post.Dto.Response.ResRegistCommentDto;
+import Remoa.BE.Post.Domain.Post;
+import Remoa.BE.Post.Domain.UploadFile;
+import Remoa.BE.Post.Dto.Response.ResRegisterCommentDto;
+import Remoa.BE.Post.Dto.Response.ThumbnailReferenceDto;
 import Remoa.BE.Post.Service.CommentService;
+import Remoa.BE.Post.Service.MyPostService;
 import Remoa.BE.exception.CustomMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static Remoa.BE.exception.CustomBody.errorResponse;
 import static Remoa.BE.exception.CustomBody.successResponse;
@@ -28,15 +34,62 @@ public class MyPostController {
 
     private final MemberService memberService;
     private final CommentService commentService;
+    private final MyPostService myPostService;
+
+    // Entity <-> DTO 간의 변환을 편리하게 하고자 ModelMapper 사용.(build.gradle에 의존성 주입 완료)
+    private final ModelMapper modelMapper = new ModelMapper();
+
     @PostMapping("/reference/{reference_id}/comment")
-    public ResponseEntity<Object> registComment(@RequestParam Map<String, String> comment, @PathVariable("reference_id") Long postId, HttpServletRequest request){
+    public ResponseEntity<Object> registComment(@RequestParam Map<String, String> comment, @PathVariable("reference_id") Long postId, HttpServletRequest request) {
         String myComment = comment.get("comment");
-        if(authorized(request)){
+        if (authorized(request)) {
             Long memberId = getMemberId();
             Member myMember = memberService.findOne(memberId);
-            ResRegistCommentDto resRegistCommentDto = commentService.registComment(myMember, myComment, postId);
-            return successResponse(CustomMessage.OK, resRegistCommentDto);
+            ResRegisterCommentDto resRegisterCommentDto = commentService.registerComment(myMember, myComment, postId);
+            return successResponse(CustomMessage.OK, resRegisterCommentDto);
         }
         return errorResponse(CustomMessage.UNAUTHORIZED);
     }
+
+    /**
+     * 내 작업물 목록 페이지
+     */
+    @GetMapping("/user/reference")
+    public ResponseEntity<Object> myReferences(HttpServletRequest request) {
+
+        if (authorized(request)) {
+            Long memberId = getMemberId();
+            Member myMember = memberService.findOne(memberId);
+
+            List<Post> allPosts = myPostService.showOnesPosts(myMember);
+            List<ThumbnailReferenceDto> myReferenceList = new ArrayList<>();
+
+            // ModelMapper initialize
+            initModelMapper();
+
+            for (Post post : allPosts) {
+                // ModelMapper 통해 Entity -> DTO 변환
+                ThumbnailReferenceDto postDTO = modelMapper.map(post, ThumbnailReferenceDto.class);
+
+                myReferenceList.add(postDTO);
+            }
+            return successResponse(CustomMessage.OK, myReferenceList);
+        }
+        return errorResponse(CustomMessage.UNAUTHORIZED);
+    }
+
+    /**
+     * Post Entity -> Thumbnail용 Response DTO를 위한 ModelMapper.
+     */
+    private void initModelMapper() {
+        modelMapper.typeMap(Post.class, ThumbnailReferenceDto.class)
+                .addMappings(mapper -> mapper.using(
+                                (Converter<Member, String>) context -> context.getSource().getNickname())
+                        .map(Post::getMember, ThumbnailReferenceDto::setNickname))
+                .addMappings(mapper -> mapper.using(
+                        (Converter<List<UploadFile>, List<String>>) context -> context.getSource().stream()
+                                .map(UploadFile::getStoreFileUrl).collect(Collectors.toList())
+                ).map(Post::getUploadFiles, ThumbnailReferenceDto::setStoreFileUrls));
+    }
+
 }

--- a/src/main/java/Remoa/BE/Post/Controller/PostController.java
+++ b/src/main/java/Remoa/BE/Post/Controller/PostController.java
@@ -1,12 +1,11 @@
 package Remoa.BE.Post.Controller;
 
-import Remoa.BE.Member.Domain.Member;
 import Remoa.BE.Member.Service.MemberService;
 import Remoa.BE.Post.Domain.Post;
 import Remoa.BE.Post.Domain.UploadFile;
 import Remoa.BE.Post.Service.PostService;
 import Remoa.BE.Post.Dto.Request.UploadPostForm;
-import Remoa.BE.Post.Dto.Response.ResReferenceDto;
+import Remoa.BE.Post.Dto.Response.ResReferenceRegisterDto;
 import Remoa.BE.exception.CustomMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +16,6 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static Remoa.BE.exception.CustomBody.errorResponse;
 import static Remoa.BE.exception.CustomBody.successResponse;
@@ -44,7 +42,7 @@ public class PostController {
 
             Post post = postService.findOne(savePost.getPostId());
 
-            ResReferenceDto resReferenceDto = ResReferenceDto.builder()
+            ResReferenceRegisterDto resReferenceRegisterDto = ResReferenceRegisterDto.builder()
                     .postId(post.getPostId())
                     .title(post.getTitle())
                     .category(post.getCategory().getName())
@@ -53,7 +51,7 @@ public class PostController {
                     .fileNames(post.getUploadFiles().stream().map(UploadFile::getOriginalFileName).collect(Collectors.toList()))
                     .build();
 
-            return successResponse(CustomMessage.OK,resReferenceDto);
+            return successResponse(CustomMessage.OK, resReferenceRegisterDto);
         }
 
         return errorResponse(CustomMessage.UNAUTHORIZED);

--- a/src/main/java/Remoa/BE/Post/Domain/Post.java
+++ b/src/main/java/Remoa/BE/Post/Domain/Post.java
@@ -72,6 +72,8 @@ public class Post {
      */
     private Integer views = 0;
 
+    private Integer scrapCount = 0;
+
     /**
      * Post에 작성되어진 Comment
      */

--- a/src/main/java/Remoa/BE/Post/Dto/Response/ResReferenceRegisterDto.java
+++ b/src/main/java/Remoa/BE/Post/Dto/Response/ResReferenceRegisterDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Builder
 @Getter
 @Setter
-public class ResReferenceDto {
+public class ResReferenceRegisterDto {
 
     private Long postId;
 

--- a/src/main/java/Remoa/BE/Post/Dto/Response/ResRegisterCommentDto.java
+++ b/src/main/java/Remoa/BE/Post/Dto/Response/ResRegisterCommentDto.java
@@ -3,7 +3,7 @@ package Remoa.BE.Post.Dto.Response;
 import lombok.Builder;
 
 @Builder
-public class ResRegistCommentDto {
+public class ResRegisterCommentDto {
     public Long commentId;
     public String comment;
     public String commentedTime;

--- a/src/main/java/Remoa/BE/Post/Dto/Response/ThumbnailReferenceDto.java
+++ b/src/main/java/Remoa/BE/Post/Dto/Response/ThumbnailReferenceDto.java
@@ -1,0 +1,30 @@
+package Remoa.BE.Post.Dto.Response;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 작업물 목록을 보여줄 때 쓰일 Post의 간단한 정보만을 담은 Dto.
+ */
+@Data
+public class ThumbnailReferenceDto {
+
+    //TODO 피그마를 통해 분석해보면 썸네일로 쓰일 Member의 profileImage 필요함. 또, 공유횟수도 추가해야하는지 확인 필요
+
+    public Long postId;
+    public String nickname;
+    public String title;
+//    public String contestName;
+//    public String deadline;
+//    public Boolean ContestAward;
+//    public String contestAwareType;
+    public Integer likeCount;
+    public String postingTime;
+    public Integer views;
+    public Integer scrapCount;
+//    public Boolean deleted;
+    public List<String> storeFileUrls;
+    public String categoryName;
+
+}

--- a/src/main/java/Remoa/BE/Post/Repository/PostRepository.java
+++ b/src/main/java/Remoa/BE/Post/Repository/PostRepository.java
@@ -33,11 +33,10 @@ public class PostRepository {
         return Optional.ofNullable(em.find(Post.class, postId));
     }
 
-    public Optional<Post> findByMemberId(Member member) {
+    public List<Post> findByMember(Member member) {
         return em.createQuery("select p from Post p where p.member = :member", Post.class)
                 .setParameter("member", member)
-                .getResultStream()
-                .findAny();
+                .getResultList();
     }
 
     public void savePostScrap(PostScarp postScarp) {

--- a/src/main/java/Remoa/BE/Post/Service/CommentService.java
+++ b/src/main/java/Remoa/BE/Post/Service/CommentService.java
@@ -5,7 +5,7 @@ import Remoa.BE.Member.Domain.CommentBookmark;
 import Remoa.BE.Member.Domain.CommentLike;
 import Remoa.BE.Member.Domain.Member;
 import Remoa.BE.Post.Domain.Post;
-import Remoa.BE.Post.Dto.Response.ResRegistCommentDto;
+import Remoa.BE.Post.Dto.Response.ResRegisterCommentDto;
 import Remoa.BE.Post.Repository.CommentRepository;
 import Remoa.BE.Post.Repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -50,19 +50,19 @@ public class CommentService {
     }
 
     @Transactional
-    public ResRegistCommentDto registComment(Member member, String comment, Long postId){
+    public ResRegisterCommentDto registerComment(Member member, String comment, Long postId){
         Comment commentObj = new Comment();
         String formatDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         commentObj.setComment(comment);
         commentObj.setCommentedTime(formatDate);
 
-        ResRegistCommentDto resRegistCommentDto = ResRegistCommentDto.builder()
+        ResRegisterCommentDto resRegisterCommentDto = ResRegisterCommentDto.builder()
                 .commentId(commentObj.getCommentId())
                 .comment(commentObj.getComment())
                 .commentedTime(commentObj.getCommentedTime())
                 .build();
 
         postRepository.saveComment(commentObj);
-        return resRegistCommentDto;
+        return resRegisterCommentDto;
     }
 }

--- a/src/main/java/Remoa/BE/Post/Service/FeedBackService.java
+++ b/src/main/java/Remoa/BE/Post/Service/FeedBackService.java
@@ -3,9 +3,11 @@ package Remoa.BE.Post.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FeedBackService {
 }

--- a/src/main/java/Remoa/BE/Post/Service/MyPostService.java
+++ b/src/main/java/Remoa/BE/Post/Service/MyPostService.java
@@ -1,11 +1,24 @@
 package Remoa.BE.Post.Service;
 
+import Remoa.BE.Member.Domain.Member;
+import Remoa.BE.Post.Domain.Post;
+import Remoa.BE.Post.Repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MyPostService {
+
+    private final PostRepository postRepository;
+
+    public List<Post> showOnesPosts(Member member) {
+        return postRepository.findByMember(member);
+    }
 }

--- a/src/main/java/Remoa/BE/Post/Service/PostService.java
+++ b/src/main/java/Remoa/BE/Post/Service/PostService.java
@@ -17,12 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostService {
 
     private final UploadFileRepository uploadFileRepository;
@@ -48,12 +51,18 @@ public class PostService {
 
         Member member = memberService.findOne(memberId);
 
+        String formatDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
         Post post = Post.builder()
                 .title(uploadPostForm.getTitle())
                 .member(member)
                 .contestName(uploadPostForm.getContestName())
                 .category(category)
                 .contestAwareType(uploadPostForm.getContestAwardType())
+                .likeCount(0)
+                .scrapCount(0)
+                .views(0)
+                .postingTime(formatDate)
                 .deleted(false)
                 .build();
 
@@ -61,7 +70,5 @@ public class PostService {
 
         return post;
     }
-
-
 
 }


### PR DESCRIPTION
## 개요
내 작업물 목록 페이지 구현, Post 작성 시간, 좋아요 수, 열람 횟수, 공유 횟수 초기화, 오탈자 수정

## 변경 사항
MyPostController에 GET 메서드로 /user/reference(내 작업물 목록)구현.
PostService의 registerPost에서 Post 작성시 초기화 되지 않았던 필드들 모두 초기화 진행.
regist -> register로 오탈자 수정.

## 확인 방법 (스크린샷 첨부 가능)
![스크린샷 2023-03-08 02 11 32](https://user-images.githubusercontent.com/69197412/223497098-6782361f-f6a9-4abe-8972-0489e95bcd3a.png)

## 한계점 / 문제점
피그마를 보면 레퍼런스 목록을 확인하는 창에 글 작성자의 이미지, post의 대표 Thumbnail 이미지가 있는데 이 부분 추가 구현이 필요해보임.
(하단 캡쳐본 빨간 박스 부분)
![스크린샷 2023-03-08 02 17 58](https://user-images.githubusercontent.com/69197412/223498926-6ab6f5d5-13e7-4934-9d4c-0130485e3596.png)
