### PR TITLE
feat: 내 활동 관리 구현

### DIFF
--- a/src/main/java/Remoa/BE/Member/Domain/Comment.java
+++ b/src/main/java/Remoa/BE/Member/Domain/Comment.java
@@ -61,5 +61,8 @@ public class Comment {
     @Column(name = "comment_like_count")
     private Integer commentLikeCount = 0;
 
+    @OneToOne
+    private CommentFeedback commentFeedback;
+
     private Boolean deleted = Boolean.FALSE;
 }

--- a/src/main/java/Remoa/BE/Member/Domain/CommentFeedback.java
+++ b/src/main/java/Remoa/BE/Member/Domain/CommentFeedback.java
@@ -1,0 +1,49 @@
+package Remoa.BE.Member.Domain;
+
+import Remoa.BE.Post.Domain.Post;
+import lombok.*;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+import static javax.persistence.FetchType.LAZY;
+
+/**
+ * 마이페이지-내 활동 관리에 쓰이는 Comment와 Feedback을 구분 없이 최신순으로 조회하기 위한 entity.
+ */
+@Builder
+@Entity
+@Getter
+@Setter
+@Where(clause = "deleted = false")
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_feedback_id")
+    private Long commentFeedbackId;
+
+
+    private ContentType type;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @OneToOne
+    private Comment comment;
+
+    @OneToOne
+    private Feedback feedback;
+
+    private LocalDateTime time;
+
+    private Boolean deleted = Boolean.FALSE;
+}

--- a/src/main/java/Remoa/BE/Member/Domain/ContentType.java
+++ b/src/main/java/Remoa/BE/Member/Domain/ContentType.java
@@ -1,0 +1,14 @@
+package Remoa.BE.Member.Domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * CommentFeedback에 comment와 Feedback 구분을 위한 enum 클래스.
+ */
+@AllArgsConstructor
+@Getter
+public enum ContentType {
+    COMMENT,
+    FEEDBACK;
+}

--- a/src/main/java/Remoa/BE/Member/Domain/Feedback.java
+++ b/src/main/java/Remoa/BE/Member/Domain/Feedback.java
@@ -65,5 +65,8 @@ public class Feedback {
     @Column(name = "feedback_like_count")
     private Integer feedbackLikeCount = 0;
 
+    @OneToOne
+    private CommentFeedback commentFeedback;
+
     private Boolean deleted = Boolean.FALSE;
 }

--- a/src/main/java/Remoa/BE/Member/Domain/Member.java
+++ b/src/main/java/Remoa/BE/Member/Domain/Member.java
@@ -101,6 +101,9 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "fromMember", cascade = {CascadeType.ALL},fetch = FetchType.LAZY)
     private List<Follow> follows = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL}, fetch = FetchType.LAZY)
+    private List<CommentFeedback> commentFeedbacks = new ArrayList<>();
+
     /**
      * ADMIN과 일반 USER를 구분하기 위해 존재. Spring Security 이용하기 위함
      */

--- a/src/main/java/Remoa/BE/Post/Controller/MyActivityController.java
+++ b/src/main/java/Remoa/BE/Post/Controller/MyActivityController.java
@@ -1,0 +1,128 @@
+package Remoa.BE.Post.Controller;
+
+import Remoa.BE.Member.Domain.CommentFeedback;
+import Remoa.BE.Member.Domain.Member;
+import Remoa.BE.Member.Dto.Res.ResMemberInfoDto;
+import Remoa.BE.Member.Service.MemberService;
+import Remoa.BE.Post.Domain.PostScarp;
+import Remoa.BE.Post.Dto.Response.ResCommentFeedbackDto;
+import Remoa.BE.Post.Dto.Response.ResPostDto;
+import Remoa.BE.Post.Service.CommentFeedbackService;
+import Remoa.BE.Post.Service.PostService;
+import Remoa.BE.exception.CustomMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static Remoa.BE.Member.Domain.ContentType.COMMENT;
+import static Remoa.BE.Member.Domain.ContentType.FEEDBACK;
+import static Remoa.BE.exception.CustomBody.errorResponse;
+import static Remoa.BE.exception.CustomBody.successResponse;
+import static Remoa.BE.utill.MemberInfo.authorized;
+import static Remoa.BE.utill.MemberInfo.getMemberId;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class MyActivityController {
+
+    private final MemberService memberService;
+    private final CommentFeedbackService commentFeedbackService;
+    private final PostService postService;
+
+    /**
+     * 내 활동 관리
+     * @param request
+     * @param commentSize
+     * @param scrapSize
+     * @return Map<String, Object>
+     *     "contents" : 내가 작성한 최신 댓글(Comment, Feedback 무관)들의 List.
+     *     "posts" : 내가 스크랩한 post들을 가장 최근 스크랩한 순서의 List.
+     * 주의사항! : page는 고정해두고 size를 이용하므로 누적 데이터가 return 됨.
+     */
+    @GetMapping("/user/activity")
+    public ResponseEntity<Object> myActivity(HttpServletRequest request,
+                                             @RequestParam(name = "comment", defaultValue = "1", required = false) int commentSize,
+                                             @RequestParam(name = "scrap", defaultValue = "1", required = false) int scrapSize) {
+
+        if (authorized(request)) {
+            Long memberId = getMemberId();
+            Member myMember = memberService.findOne(memberId);
+
+            Map<String, Object> result = new HashMap<>();
+
+            Page<CommentFeedback> commentOrFeedback = commentFeedbackService.findNewestCommentOrFeedback(myMember, commentSize);
+
+            /**
+             * 조회한 가장 최근에 작성한 댓글들을 dto로 mapping
+             */
+            List<ResCommentFeedbackDto> contents = commentOrFeedback.stream().map(commentFeedback -> {
+                ResCommentFeedbackDto map = null;
+                if (commentFeedback.getType().equals(FEEDBACK)) {
+                    map = ResCommentFeedbackDto.builder()
+                            .title(commentFeedback.getPost().getTitle())
+                            .postId(commentFeedback.getPost().getPostId())
+                            .thumbnail(commentFeedback.getPost().getThumbnail().getStoreFileUrl())
+                            .member(new ResMemberInfoDto(commentFeedback.getMember().getMemberId(),
+                                    commentFeedback.getMember().getNickname(),
+                                    commentFeedback.getMember().getProfileImage()))
+                            .content(commentFeedback.getFeedback().getFeedback())
+                            .likeCount(commentFeedback.getFeedback().getFeedbackLikeCount()).build();
+                } else if (commentFeedback.getType().equals(COMMENT)) {
+                    map = ResCommentFeedbackDto.builder()
+                            .title(commentFeedback.getPost().getTitle())
+                            .postId(commentFeedback.getPost().getPostId())
+                            .thumbnail(commentFeedback.getPost().getThumbnail().getStoreFileUrl())
+                            .member(new ResMemberInfoDto(commentFeedback.getMember().getMemberId(),
+                                    commentFeedback.getMember().getNickname(),
+                                    commentFeedback.getMember().getProfileImage()))
+                            .content(commentFeedback.getComment().getComment())
+                            .likeCount(commentFeedback.getComment().getCommentLikeCount()).build();
+                }
+                return map;
+            }).collect(Collectors.toList());
+
+            result.put("contents", contents);
+
+            scrapSize *= 12; //스크랩한 post는 12개씩 보여주므로.
+
+            /**
+             * 조회한 최근에 스크랩한 12개의 post들을 dto로 mapping.
+             */
+            List<ResPostDto> posts = postService.findScrapedPost(scrapSize, myMember)
+                    .stream()
+                    .map(PostScarp::getPost)
+                    .collect(Collectors.toList())
+                    .stream()
+                    .map(post -> ResPostDto.builder()
+                            .postId(post.getPostId())
+                            .postMember(new ResMemberInfoDto(post.getMember().getMemberId(),
+                                    post.getMember().getNickname(),
+                                    post.getMember().getProfileImage()))
+                            .thumbnail(post.getThumbnail().getStoreFileUrl())
+                            .title(post.getTitle())
+                            .likeCount(post.getLikeCount())
+                            .postingTime(post.getPostingTime().toString())
+                            .views(post.getViews())
+                            .scrapCount(post.getScrapCount())
+                            .categoryName(post.getCategory().getName()).build())
+                    .collect(Collectors.toList());
+
+            result.put("posts", posts);
+
+            return successResponse(CustomMessage.OK, result);
+        }
+        return errorResponse(CustomMessage.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/Remoa/BE/Post/Domain/Post.java
+++ b/src/main/java/Remoa/BE/Post/Domain/Post.java
@@ -1,6 +1,8 @@
 package Remoa.BE.Post.Domain;
 
 import Remoa.BE.Member.Domain.Comment;
+import Remoa.BE.Member.Domain.CommentFeedback;
+import Remoa.BE.Member.Domain.Feedback;
 import Remoa.BE.Member.Domain.Member;
 import lombok.*;
 import org.hibernate.annotations.Where;
@@ -89,6 +91,12 @@ public class Post {
      */
     @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<Feedback> feedbacks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<CommentFeedback> commentFeedbacks = new ArrayList<>();
 
     /**
      * Post에서 쓰인 files

--- a/src/main/java/Remoa/BE/Post/Domain/PostScarp.java
+++ b/src/main/java/Remoa/BE/Post/Domain/PostScarp.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -29,11 +30,15 @@ public class PostScarp {
     @JoinColumn(name = "post_id")
     private Post post;
 
+    @Column(name = "scrap_time")
+    private LocalDateTime scrapTime;
+
     private Boolean deleted = Boolean.FALSE;
 
     public static PostScarp createPostScrap(Member member, Post post) {
         PostScarp postScrap = new PostScarp();
         postScrap.setPost(post);
+        postScrap.setScrapTime(LocalDateTime.now());
         postScrap.setMember(member);
 
         return postScrap;

--- a/src/main/java/Remoa/BE/Post/Dto/Response/ResCommentFeedbackDto.java
+++ b/src/main/java/Remoa/BE/Post/Dto/Response/ResCommentFeedbackDto.java
@@ -1,0 +1,21 @@
+package Remoa.BE.Post.Dto.Response;
+
+import Remoa.BE.Member.Dto.Res.ResMemberInfoDto;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 내 활동 관리에 쓰이는 Comment와 Feedback을 구분 없이 최신순으로 볼러오는 데 쓰이는 dto.
+ */
+@Data
+@Builder
+public class ResCommentFeedbackDto {
+
+    private String title;
+    private Long postId;
+    private String thumbnail;
+    private ResMemberInfoDto member;
+    private String content;
+    private Integer likeCount;
+
+}

--- a/src/main/java/Remoa/BE/Post/Repository/CommentFeedbackRepository.java
+++ b/src/main/java/Remoa/BE/Post/Repository/CommentFeedbackRepository.java
@@ -1,0 +1,13 @@
+package Remoa.BE.Post.Repository;
+
+import Remoa.BE.Member.Domain.CommentFeedback;
+import Remoa.BE.Member.Domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentFeedbackRepository extends JpaRepository<CommentFeedback, Long> {
+
+    Page<CommentFeedback> findByMemberOrderByTimeDesc(Pageable pageable, Member member);
+
+}

--- a/src/main/java/Remoa/BE/Post/Repository/PostScrapRepository.java
+++ b/src/main/java/Remoa/BE/Post/Repository/PostScrapRepository.java
@@ -1,9 +1,14 @@
 package Remoa.BE.Post.Repository;
 
+import Remoa.BE.Member.Domain.Member;
 import Remoa.BE.Post.Domain.PostScarp;
 import Remoa.BE.Post.Service.PostService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostScrapRepository extends JpaRepository<PostScarp, Long> {
     PostScarp findByMemberMemberIdAndPostPostId(Long memberId, Long postId);
+
+    Page<PostScarp> findByMemberOrderByScrapTimeDesc(Pageable pageable, Member member);
 }

--- a/src/main/java/Remoa/BE/Post/Service/CommentFeedbackService.java
+++ b/src/main/java/Remoa/BE/Post/Service/CommentFeedbackService.java
@@ -1,0 +1,42 @@
+package Remoa.BE.Post.Service;
+
+import Remoa.BE.Member.Domain.*;
+import Remoa.BE.Post.Domain.Post;
+import Remoa.BE.Post.Repository.CommentFeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentFeedbackService {
+
+    private final CommentFeedbackRepository commentFeedbackRepository;
+
+    @Transactional
+    public CommentFeedback saveCommentFeedback(Comment comment, Feedback feedback, ContentType type,
+                                               Member member, Post post, LocalDateTime time) {
+
+        CommentFeedback commentFeedback = CommentFeedback.builder()
+                .type(type)
+                .member(member)
+                .post(post)
+                .comment(comment)
+                .feedback(feedback)
+                .time(time)
+                .deleted(false).build();
+        return commentFeedbackRepository.save(commentFeedback);
+    }
+
+    public Page<CommentFeedback> findNewestCommentOrFeedback(Member member, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        return commentFeedbackRepository.findByMemberOrderByTimeDesc(pageable, member);
+    }
+
+}

--- a/src/main/java/Remoa/BE/Post/Service/CommentService.java
+++ b/src/main/java/Remoa/BE/Post/Service/CommentService.java
@@ -17,6 +17,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static Remoa.BE.Member.Domain.ContentType.COMMENT;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -27,6 +29,7 @@ public class CommentService {
     private final CommentLikeRepository commentLikeRepository;
     private final PostService postService;
     private final CommentPagingRepository commentPagingRepository;
+    private final CommentFeedbackService commentFeedbackService;
 
     @Transactional
     public Long writeComment(Comment comment) {
@@ -68,14 +71,19 @@ public class CommentService {
         Comment commentObj = new Comment();
 //        String formatDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         Post post = postService.findOne(postId);
+        LocalDateTime time = LocalDateTime.now();
 
         commentObj.setPost(post);
         commentObj.setMember(member);
         commentObj.setParentComment(parentComment); //대댓글인 경우 원 댓글의 Feedback, 댓글인 경우 null
         commentObj.setComment(comment);
         commentObj.setCommentLikeCount(0);
-        commentObj.setCommentedTime(LocalDateTime.now());
+        commentObj.setCommentedTime(time);
         commentRepository.saveComment(commentObj);
+
+        if (parentComment == null) {
+            commentFeedbackService.saveCommentFeedback(commentObj, null, COMMENT, member, post, time);
+        }
 
         return commentObj;
 

--- a/src/main/java/Remoa/BE/Post/Service/FeedbackService.java
+++ b/src/main/java/Remoa/BE/Post/Service/FeedbackService.java
@@ -1,8 +1,6 @@
 package Remoa.BE.Post.Service;
 
-import Remoa.BE.Member.Domain.Feedback;
-import Remoa.BE.Member.Domain.FeedbackLike;
-import Remoa.BE.Member.Domain.Member;
+import Remoa.BE.Member.Domain.*;
 import Remoa.BE.Member.Service.MemberService;
 import Remoa.BE.Post.Domain.Post;
 import Remoa.BE.Post.Domain.UploadFile;
@@ -24,6 +22,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static Remoa.BE.Member.Domain.ContentType.*;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -32,7 +32,8 @@ public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
     private final FeedbackLikeRepository feedbackLikeRepository;
     private final PostService postService;
-    private final MemberService memberService;
+    private final CommentFeedbackService commentFeedbackService;
+
     @Transactional
     public Feedback findOne(Long feedbackId){
         Optional<Feedback> feedback = feedbackRepository.findOne(feedbackId);
@@ -58,16 +59,21 @@ public class FeedbackService {
         Feedback feedbackObj = new Feedback();
         Post post = postService.findOne(postId);
 
-//        String formatDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        LocalDateTime time = LocalDateTime.now();
+
         feedbackObj.setPost(post);
         feedbackObj.setMember(member);
         feedbackObj.setParentFeedback(parentFeedback); //대댓글인 경우 원 댓글의 Feedback, 댓글인 경우 null
         feedbackObj.setPageNumber(pageNumber); //대댓글인 경우 null. parentFeedback.getPageNumber()통헤서 값 넣어도 됩니다.
         feedbackObj.setFeedback(feedback);
         feedbackObj.setFeedbackLikeCount(0);
-        feedbackObj.setFeedbackTime(LocalDateTime.now());
-
+        feedbackObj.setFeedbackTime(time);
         feedbackRepository.saveFeedback(feedbackObj);
+
+        if (parentFeedback == null) {
+            commentFeedbackService.saveCommentFeedback(null, feedbackObj, FEEDBACK, member, post, time);
+        }
+
     }
 
     @Transactional

--- a/src/main/java/Remoa/BE/Post/Service/MyPostService.java
+++ b/src/main/java/Remoa/BE/Post/Service/MyPostService.java
@@ -90,4 +90,15 @@ public class MyPostService {
         return postPagingRepository.findByMemberAndCommentsIsNotEmpty(pageable, member);
     }
 
+    /**
+     * 내 활동 관리에 쓰이는 코멘트 및 피드백을 단 작업물
+     * @param size
+     * @param member
+     * @return Post
+     */
+    public Page<Post> getCommentedPost(int size, Member member) {
+        PageRequest pageable = PageRequest.of(0, size, Sort.by("postingTime").descending());
+        return postPagingRepository.findByMemberAndCommentsIsNotEmpty(pageable, member);
+    }
+
 }


### PR DESCRIPTION
## 개요
내 활동 관리 구현

## 변경 사항
MyActivityController 구현
Comment와 Feedback을 구분 없이 가장 최근에 작성한 댓글을 조회하기 위한 CommentFeedback 구현
최근 스크랩한 Post를 조회하기 위해 PostScrap에 LocalDateTime time 필드 추가, 엔티티 생성시 현재 시간으로 초기화
response에 쓸 ResCommentFeedbackDto 생성
CommentFeedbackRepository 구현
CommentFeedbackService 구현

## 확인 방법 (스크린샷 첨부 가능)

## 한계점 / 문제점
기존에는 페이징 기능을 구현 할 때 size를 고정하고 page 값을 parameter로 받아서 데이터를 응답에 써 프론트엔드에서 누적 데이터를 다루게 했다면,
이번 기능 구현에서는 반대로 size를 parameter로 받고 page를 고정해서 누적값을 백엔드에서 다뤄 응답함.
